### PR TITLE
Add mapping generator script

### DIFF
--- a/crawler/config.py
+++ b/crawler/config.py
@@ -7,18 +7,42 @@ logger = structlog.get_logger()
 _hasErrored: bool = False
 
 
-def _requiredEnvVar(key: str) -> str:
+def _required_env_var(key: str) -> str:
     global _hasErrored
 
     x = os.getenv(key)
     if x is None:
-        logger.fatal(f"missing required environment variable {key}")
+        logger.error(f"missing required environment variable {key}")
         _hasErrored = True
     return x
 
 
-COORDINATOR_SERVE_PORT = _requiredEnvVar("SURCHABLE_COORDINATOR_SERVE_PORT")
-COORDINATOR_SERVE_HOST = _requiredEnvVar("SURCHABLE_COORDINATOR_SERVE_HOST")
+def _env_var_default(key: str, default: str) -> str:
+    x = os.getenv(key)
+    if x is None:
+        return default
+    return x
+
+
+"""[[[cog
+import cog
+from generateMappings import *
+cog.outl(
+	generate_python_configuration(
+		parse_configuration(
+			load_raw_configuration(),
+		),
+	),
+)
+]]]"""
+DB_DATABASE_NAME = _required_env_var("SURCHABLE_DB_DATABASE_NAME")
+DB_USER = _required_env_var("SURCHABLE_DB_USER")
+DB_PASSWORD = _required_env_var("SURCHABLE_DB_PASSWORD")
+DB_HOST = _required_env_var("SURCHABLE_DB_HOST")
+COORDINATOR_SERVE_PORT = _env_var_default("SURCHABLE_COORDINATOR_SERVE_PORT", "7200")
+COORDINATOR_SERVE_HOST = _env_var_default("SURCHABLE_COORDINATOR_SERVE_HOST", "0.0.0.0")
+
+# [[[end]]]
 
 if _hasErrored:
     sys.exit(1)

--- a/crawler/urls.py
+++ b/crawler/urls.py
@@ -1,0 +1,17 @@
+"""[[[cog
+import cog
+from generateMappings import *
+cog.outl(
+	generate_python_url_mapping(
+		parse_url_mappings(
+			load_raw_url_mappings(),
+		),
+	),
+)
+]]]"""
+OK = "/ok"
+ADD_DOMAIN_TO_CRAWL_QUEUE = "/job/add"
+CRAWLER_REQUEST_JOB = "/job/request"
+REQUEST_PREFLIGHT_CHECK = "/page/preflight"
+
+# [[[end]]]

--- a/generateMappings.py
+++ b/generateMappings.py
@@ -1,0 +1,105 @@
+import re
+from typing import *
+
+_camel_to_snake_pattern = re.compile(r"(?<!^)(?=[A-Z])")
+
+
+def _camel_to_snake(inp: str) -> str:
+    if inp.upper() == inp:
+        return inp
+    return _camel_to_snake_pattern.sub("_", inp)
+
+
+def _fields(inp: str) -> List[str]:
+    return list(filter(lambda x: x != "", inp.split(" ")))
+
+
+
+def parse_url_mappings(raw: str) -> Dict[str, str]:
+    mappings: Dict[str, str] = {}
+
+    for i, line in enumerate(raw.strip().splitlines()):
+        if line == "":
+            continue
+        fields = _fields(line)
+        assert (
+            len(fields) == 2
+        ), f"Line {i+1} has an invalid number of fields, {len(fields)}. It must have 2."
+
+        mappings[fields[0]] = fields[1]
+
+    return mappings
+
+
+def generate_golang_url_mapping(mapping: Dict[str, str], package_name: str) -> str:
+    o = f"""package {package_name}\n\nconst (\n"""
+
+    for key in mapping:
+        o += f'\t{key} = "{mapping[key]}"\n'
+
+    o += ")\n"
+
+    return o
+
+
+def generate_python_url_mapping(mapping: Dict[str, str]):
+    o = ""
+    for key in mapping:
+        o += f'{_camel_to_snake(key).upper()} = "{mapping[key]}"\n'
+    return o
+
+
+def parse_configuration(raw: str) -> Dict[str, Tuple[str, Optional[str]]]:
+    mappings: Dict[str, Tuple[str, Optional[str]]] = None
+
+    for i, line in enumerate(_fields(raw)):
+        if line == "":
+            continue
+
+        fields = _fields(line)
+
+        assert len(fields) >= 3, str(i+1)
+
+        if fields[0] == "must":
+            mappings[fields[1]] = (fields[2], None)
+        elif fields[1] == "default":
+            mappings[fields[2]] = (fields[3], fields[1])
+
+    return mappings
+
+def generate_golang_configuration(mapping: Dict[str, Tuple[str, Optional[str]]], package_name: str) -> str:
+    raise NotImplementedError("generate_golang_configuration")
+
+def generate_python_configuration(mapping: Dict[str, Tuple[str, Optional[str]]]) -> str:
+    raise NotImplementedError("generate_python_configuration")
+
+
+def run_url_mappings():
+    mappings: Dict[str, str] = {}
+    with open("mappings/urls") as f:
+        mappings = parse_url_mappings(f.read())
+
+    with open("internal/urls/urls.go", "w") as f:
+        f.write(generate_golang_url_mapping(mappings, "urls"))
+
+    with open("crawler/urls.py", "w") as f:
+        f.write(generate_python_url_mapping(mappings))
+
+
+def run_configuration():
+    mappings: Dict[str, Tuple[str, Optional[str]]] = {}
+    with open("mappings/configuration") as f:
+        mappings = parse_configuration(f.read())
+
+    with open("internal/config/envVars.go", "w") as f:
+        f.write(generate_golang_configuration(mappings, "urls"))
+
+    with open("crawler/envVars.py", "w") as f: # TODO: Change this to replace part of the file instead.
+        f.write(generate_python_url_mapping(mappings))
+
+
+# TODO: Reimplement this with Cog preprocessor??
+
+
+if __name__ == "__main__":
+    run_url_mappings()

--- a/generateMappings.py
+++ b/generateMappings.py
@@ -14,7 +14,6 @@ def _fields(inp: str) -> List[str]:
     return list(filter(lambda x: x != "", inp.split(" ")))
 
 
-
 def parse_url_mappings(raw: str) -> Dict[str, str]:
     mappings: Dict[str, str] = {}
 
@@ -31,8 +30,8 @@ def parse_url_mappings(raw: str) -> Dict[str, str]:
     return mappings
 
 
-def generate_golang_url_mapping(mapping: Dict[str, str], package_name: str) -> str:
-    o = f"""package {package_name}\n\nconst (\n"""
+def generate_golang_url_mapping(mapping: Dict[str, str]) -> str:
+    o = "const (\n"
 
     for key in mapping:
         o += f'\t{key} = "{mapping[key]}"\n'
@@ -50,9 +49,9 @@ def generate_python_url_mapping(mapping: Dict[str, str]):
 
 
 def parse_configuration(raw: str) -> Dict[str, Tuple[str, Optional[str]]]:
-    mappings: Dict[str, Tuple[str, Optional[str]]] = None
+    mappings: Dict[str, Tuple[str, Optional[str]]] = {}
 
-    for i, line in enumerate(_fields(raw)):
+    for i, line in enumerate(raw.splitlines()):
         if line == "":
             continue
 
@@ -62,44 +61,61 @@ def parse_configuration(raw: str) -> Dict[str, Tuple[str, Optional[str]]]:
 
         if fields[0] == "must":
             mappings[fields[1]] = (fields[2], None)
-        elif fields[1] == "default":
+        elif fields[0] == "default":
             mappings[fields[2]] = (fields[3], fields[1])
 
     return mappings
 
-def generate_golang_configuration(mapping: Dict[str, Tuple[str, Optional[str]]], package_name: str) -> str:
-    raise NotImplementedError("generate_golang_configuration")
+def generate_golang_configuration(mapping: Dict[str, Tuple[str, Optional[str]]]) -> str:
+    highLevelTypes: Dict[str, Tuple[str, str, Optional[str]]] = {}
+    for key in mapping:
+        kc = key.count(".")
+        sp = key.split(".")
+        if kc == 1:
+            x = highLevelTypes.get(sp[0], [])
+            if type(x) != list:
+                raise ValueError(f"duplicated key {sp}")
+            x.append((sp[1], mapping[key][0], mapping[key][1]))
+            highLevelTypes[sp[0]] = x
+        elif kc == 0:
+            highLevelTypes[key] = (key, mapping[key][0], mapping[key][1])
+        else:
+            raise NotImplementedError("subtypes more than one level deep")
+
+    o = ""
+
+    def formFunctionCall(x: Tuple[str, str, Optional[str]]) -> str:
+        return ('requireEnvVar' if x[2] is None else 'envVarDefault') + "(\"" + x[1] + "\"" + (', \"' + x[2] + '\"' if x[2] is not None else '') + ")"
+
+    for key in highLevelTypes:
+        val = highLevelTypes[key]
+        if type(val) == tuple:
+            o += f"var {key} = {formFunctionCall(val)})\n"
+        if type(val) == list:
+            o += f"var {key} = struct{{\n"
+            for var in val:
+                o += f"{var[0]} string\n"
+            o += "}{\n"
+            for var in val:
+                o += f"{var[0]}: {formFunctionCall(var)},\n"
+            o += "}\n"
+
+    return o
 
 def generate_python_configuration(mapping: Dict[str, Tuple[str, Optional[str]]]) -> str:
-    raise NotImplementedError("generate_python_configuration")
+    o = ""
+    for key in mapping:
+        x = mapping[key]
+        joined_key = ("_".join(map(_camel_to_snake, key.split(".")))).upper()
+        o += joined_key + " = " + ('_required_env_var' if x[1] is None else '_env_var_default') + "(\"" + x[0] + "\"" + (', \"' + x[1] + '\"' if x[1] is not None else '') + ")\n"
+    return o
 
 
-def run_url_mappings():
-    mappings: Dict[str, str] = {}
+def load_raw_url_mappings() -> str:
     with open("mappings/urls") as f:
-        mappings = parse_url_mappings(f.read())
-
-    with open("internal/urls/urls.go", "w") as f:
-        f.write(generate_golang_url_mapping(mappings, "urls"))
-
-    with open("crawler/urls.py", "w") as f:
-        f.write(generate_python_url_mapping(mappings))
+        return f.read()
 
 
-def run_configuration():
-    mappings: Dict[str, Tuple[str, Optional[str]]] = {}
+def load_raw_configuration() -> str:
     with open("mappings/configuration") as f:
-        mappings = parse_configuration(f.read())
-
-    with open("internal/config/envVars.go", "w") as f:
-        f.write(generate_golang_configuration(mappings, "urls"))
-
-    with open("crawler/envVars.py", "w") as f: # TODO: Change this to replace part of the file instead.
-        f.write(generate_python_url_mapping(mappings))
-
-
-# TODO: Reimplement this with Cog preprocessor??
-
-
-if __name__ == "__main__":
-    run_url_mappings()
+        return f.read()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,19 +33,28 @@ func envVarDefault(key string, defaultValue string) string {
 	return x
 }
 
+/*[[[cog
+import cog
+from generateMappings import *
+cog.outl(
+	generate_golang_configuration(
+		parse_configuration(
+			load_raw_configuration(),
+		),
+	),
+)
+]]]*/
 var DB = struct {
 	DatabaseName string
 	User         string
 	Password     string
 	Host         string
-	TablePrefix  string
 }{
 	DatabaseName: requireEnvVar("SURCHABLE_DB_DATABASE_NAME"),
 	User:         requireEnvVar("SURCHABLE_DB_USER"),
 	Password:     requireEnvVar("SURCHABLE_DB_PASSWORD"),
 	Host:         requireEnvVar("SURCHABLE_DB_HOST"),
 }
-
 var Coordinator = struct {
 	ServePort string
 	ServeHost string
@@ -53,3 +62,5 @@ var Coordinator = struct {
 	ServePort: envVarDefault("SURCHABLE_COORDINATOR_SERVE_PORT", "7200"),
 	ServeHost: envVarDefault("SURCHABLE_COORDINATOR_SERVE_HOST", "0.0.0.0"),
 }
+
+// [[[end]]]

--- a/internal/urls/urls.go
+++ b/internal/urls/urls.go
@@ -1,0 +1,21 @@
+package urls
+
+/*[[[cog
+import cog
+from generateMappings import *
+cog.outl(
+	generate_golang_url_mapping(
+		parse_url_mappings(
+			load_raw_url_mappings(),
+		),
+	),
+)
+]]]*/
+const (
+	OK                    = "/ok"
+	AddDomainToCrawlQueue = "/job/add"
+	CrawlerRequestJob     = "/job/request"
+	RequestPreflightCheck = "/page/preflight"
+)
+
+// [[[end]]]

--- a/mappings/configuration
+++ b/mappings/configuration
@@ -1,0 +1,7 @@
+must DB.DatabaseName SURCHABLE_DB_DATABASE_NAME
+must DB.User         SURCHABLE_DB_USER
+must DB.Password     SURCHABLE_DB_PASSWORD
+must DB.Host         SURCHABLE_DB_HOST
+
+default 7200    Coordinator.ServePort SURCHABLE_COORDINATOR_SERVE_PORT
+default 0.0.0.0 Coordinator.ServeHost SURCHABLE_COORDINATOR_SERVE_HOST

--- a/mappings/urls
+++ b/mappings/urls
@@ -1,0 +1,6 @@
+OK /ok
+
+AddDomainToCrawlQueue /job/add
+CrawlerRequestJob     /job/request
+
+RequestPreflightCheck /page/preflight

--- a/runMappingGeneration.sh
+++ b/runMappingGeneration.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -ex
+
+cog -rU -I . --verbosity=1 internal/config/config.go internal/urls/urls.go crawler/urls.py crawler/config.py
+
+black crawler/urls.py crawler/config.py
+go fmt ./internal/config/ ./internal/urls/


### PR DESCRIPTION
This is a script that reads basic files that define:

* mappings between internal variables used to refer to URLs from the coordinator and strings of the URLs themselves
* mappings between internal variables used to refer to the contents of environment variables and optional their defaults

**This is not currently ready to be merged.**